### PR TITLE
Fix: Remove queue code modal 

### DIFF
--- a/src/TA/HomeScreen/TAHomeScreen.js
+++ b/src/TA/HomeScreen/TAHomeScreen.js
@@ -22,17 +22,8 @@ export default class TAHomeScreen extends React.Component {
 
     taDeparted = async () => {
         const current_office_hours_id = this.state.upcomingOfficeHours[0].id
-        let data, error;
-        let update_status_response = await apiUpdateTAStatus(current_office_hours_id, 'departed')
-        // FIXME -- Is there a way to declare "const {data, error}" twice in one function?
-        data = update_status_response.data;
-        error = update_status_response.error;
-        console.log("taDeparted data:", data)
-        this.setState({fetch_error: error})
+        const {data, error} = await apiUpdateTAStatus(current_office_hours_id, 'departed')
         this.props.navigation.navigate('TAHome')
-        let upcoming_hours_response = await apiFetchUpcomingOfficeHours()
-        data = upcoming_hours_response.data
-        error = upcoming_hours_response.error
         this.setState({upcomingOfficeHours: data, fetch_error: error, loading: false})
     }
 

--- a/src/TA/HomeScreen/TAHomeScreen.js
+++ b/src/TA/HomeScreen/TAHomeScreen.js
@@ -22,18 +22,24 @@ export default class TAHomeScreen extends React.Component {
 
     taDeparted = async () => {
         const current_office_hours_id = this.state.upcomingOfficeHours[0].id
-        const {data_ta_status, error_ta_status} = await apiUpdateTAStatus(current_office_hours_id, 'departed')
-        console.log("taDeparted data:", data_ta_status)
-        this.setState({fetch_error: error_ta_status})
+        let data, error;
+        let update_status_response = await apiUpdateTAStatus(current_office_hours_id, 'departed')
+        // FIXME -- Is there a way to declare "const {data, error}" twice in one function?
+        data = update_status_response.data;
+        error = update_status_response.error;
+        console.log("taDeparted data:", data)
+        this.setState({fetch_error: error})
         this.props.navigation.navigate('TAHome')
-        let {upcoming_hours_data, upcoming_hours_error} = await apiFetchUpcomingOfficeHours()
-        this.setState({upcomingOfficeHours: upcoming_hours_data, fetch_error: upcoming_hours_error, loading: false})
+        let upcoming_hours_response = await apiFetchUpcomingOfficeHours()
+        data = upcoming_hours_response.data
+        error = upcoming_hours_response.error
+        this.setState({upcomingOfficeHours: data, fetch_error: error, loading: false})
     }
 
     taArrived = async () => {
         const current_office_hours_id = this.state.upcomingOfficeHours[0].id
         const {data, error} = await apiUpdateTAStatus(current_office_hours_id, 'arrived')
-        console.log("taArrived data", data)
+        console.log("taArrived data:", data)
         const queue_id = data.id
         this.props.navigation.navigate('TAQueueScreen',
             {
@@ -91,6 +97,7 @@ export default class TAHomeScreen extends React.Component {
     }
 
     hasCurrentlyOpenOfficeHours = () => {
+        console.log("home screeen state", this.state);
         const {upcomingOfficeHours} = this.state;
         return upcomingOfficeHours.length && upcomingOfficeHours[0].queue !== null
     }
@@ -140,7 +147,7 @@ export default class TAHomeScreen extends React.Component {
                     {
                         queue_id: upcomingOfficeHours[0].queue,
                         office_hours_id: upcomingOfficeHours[0].id,
-                        'ta_departed': this.taDeparted()
+                        'ta_departed': this.taDeparted
                     })
                 return null
             }

--- a/src/TA/HomeScreen/TAHomeScreen.js
+++ b/src/TA/HomeScreen/TAHomeScreen.js
@@ -45,7 +45,6 @@ export default class TAHomeScreen extends React.Component {
             {
                 queue_id: queue_id,
                 office_hours_id: current_office_hours_id,
-                show_modal: true,
                 'taDeparted': this.taDeparted,
             })
         this.setState({loading: true})
@@ -147,7 +146,7 @@ export default class TAHomeScreen extends React.Component {
                     {
                         queue_id: upcomingOfficeHours[0].queue,
                         office_hours_id: upcomingOfficeHours[0].id,
-                        'ta_departed': this.taDeparted
+                        'taDeparted': this.taDeparted
                     })
                 return null
             }

--- a/src/TA/QueueScreen/QueueScreen.js
+++ b/src/TA/QueueScreen/QueueScreen.js
@@ -26,20 +26,17 @@ export default class QueueScreen extends React.Component {
         office_hours_id: null,
         tickets: [],
         loading: true,
-        show_modal: false,
         fetch_error: null,
     };
 
     async componentDidMount() {
         const username = await AsyncStorage.getItem('username');
-        const show_modal = await this.props.navigation.getParam('show_modal', 'false');
         const queue_id = await this.props.navigation.getParam('queue_id', null);
         const office_hours_id = await this.props.navigation.getParam('office_hours_id', null);
         this.setState({
             username: username,
             queue_id: queue_id,
             office_hours_id: office_hours_id,
-            show_modal: show_modal,
         })
 
         this.fetchQueueData()
@@ -79,20 +76,16 @@ export default class QueueScreen extends React.Component {
         this.props.navigation.navigate('TAHome')
     }
 
-    closeModal = () => {
-        this.setState({show_modal: false});
-    }
-
-    retrieveTicketsCurrentlyHelping = () => {
+    getTicketsCurrentlyHelping = () => {
         const ticketsCurrentlyHelping = this.state.tickets.filter(ticket => (ticket.ta_helped === this.state.username && ticket.status === "In Progress"))
         console.log("tickets Currently Helping: ", ticketsCurrentlyHelping)
         return ticketsCurrentlyHelping
     }
 
     render() {
-        const ticketsCurrentlyHelping = this.retrieveTicketsCurrentlyHelping()
+        const ticketsCurrentlyHelping = this.getTicketsCurrentlyHelping()
         const ticketsShownInQueue = this.state.tickets.filter(ticket => (ticket.status !== "Closed"))
-        const {loading, show_modal, queue_code} = this.state
+        const {loading} = this.state
         console.log("queue id:", this.state.queue_id)
         if (!loading) {
             return (
@@ -109,9 +102,6 @@ export default class QueueScreen extends React.Component {
                             </Button>
                         </Right>
                     </Header>
-                    { (show_modal) ?
-                        <QueueCode modalVisible={true} closeModal={this.closeModal} queueCode={queue_code}/>
-                        : null }
                     <Tabs>
                         <Tab heading="Currently Helping">
                             <ScrollView style={styles.content}>

--- a/src/TA/QueueScreen/QueueScreen.js
+++ b/src/TA/QueueScreen/QueueScreen.js
@@ -104,7 +104,7 @@ export default class QueueScreen extends React.Component {
                             <Title>Queue</Title>
                         </Body>
                         <Right style={{flex: 1}}>
-                            <Button transparent onPress={() => this.updateQueue()}>
+                            <Button transparent onPress={() => this.fetchQueueData()}>
                                 <Icon name='refresh'/>
                             </Button>
                         </Right>

--- a/src/TA/api.js
+++ b/src/TA/api.js
@@ -21,7 +21,7 @@ export const apiUpdateTAStatus = async (office_hours_id, new_status) => {
         }
     })
 
-    console.log("api Update TA status response", response)
+    console.log("Update TA status response", response)
     return response
 }
 


### PR DESCRIPTION
* Fixes a bug that was not allowing the upcoming office hours of a ta to be update when they 'departed' from office hours
* Removes the modal popup that shows the queue code when a ta first arrives and joins a queue 